### PR TITLE
7 bug burning through gemini quota

### DIFF
--- a/server/services/ai-service/services/eventOptimizer.js
+++ b/server/services/ai-service/services/eventOptimizer.js
@@ -3,7 +3,7 @@ const { GoogleGenerativeAI } = require('@google/generative-ai');
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
 
 async function optimizeEventTime(category, location, pastEvents) {
-  const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+  const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
   const eventsData = pastEvents
     .map((e) => `Date: ${e.date}, Attendees: ${e.attendeeCount}`)

--- a/server/services/ai-service/services/matching.js
+++ b/server/services/ai-service/services/matching.js
@@ -3,7 +3,7 @@ const { GoogleGenerativeAI } = require('@google/generative-ai');
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
 
 async function matchVolunteers(event) {
-  const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+  const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
   const prompt = `You are a volunteer matching assistant for a community platform.
 

--- a/server/services/ai-service/services/sentiment.js
+++ b/server/services/ai-service/services/sentiment.js
@@ -3,7 +3,7 @@ const { GoogleGenerativeAI } = require('@google/generative-ai');
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
 
 async function analyzeSentiment(text) {
-  const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+  const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
   const prompt = `Analyze the sentiment of the following text.
 Respond with EXACTLY one word: "positive", "neutral", or "negative".

--- a/server/services/ai-service/services/summarization.js
+++ b/server/services/ai-service/services/summarization.js
@@ -3,7 +3,7 @@ const { GoogleGenerativeAI } = require('@google/generative-ai');
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
 
 async function summarizeText(text) {
-  const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+  const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
   const prompt = `You are a community discussion summarizer.
 Summarize the following community discussion into 3-5 key bullet points.

--- a/server/services/ai-service/services/trends.js
+++ b/server/services/ai-service/services/trends.js
@@ -3,7 +3,7 @@ const { GoogleGenerativeAI } = require('@google/generative-ai');
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
 
 async function detectTrends(posts) {
-  const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+  const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
   const postsText = posts
     .map((p) => `Title: ${p.title}\nContent: ${p.content}\nTags: ${(p.tags || []).join(', ')}`)

--- a/server/services/community-service/resolvers/communityResolvers.js
+++ b/server/services/community-service/resolvers/communityResolvers.js
@@ -3,6 +3,9 @@ const Post = require('../models/Post');
 
 const AI_SERVICE_URL = `http://localhost:${process.env.AI_SERVICE_PORT || 4004}`;
 
+const TRENDS_TTL_MS = 10 * 60 * 1000;
+let trendsCache = { data: null, expiresAt: 0 };
+
 const resolvers = {
   Query: {
     getPosts: async (_, { category, limit = 20, offset = 0 }) => {
@@ -32,12 +35,20 @@ const resolvers = {
     },
 
     getTrendingTopics: async () => {
+      if (trendsCache.data && Date.now() < trendsCache.expiresAt) {
+        return trendsCache.data;
+      }
+
       try {
-        // Get recent posts and let AI detect trends
         const recentPosts = await Post.find()
           .sort({ createdAt: -1 })
           .limit(100)
           .select('title content tags');
+
+        if (recentPosts.length === 0) {
+          trendsCache = { data: [], expiresAt: Date.now() + TRENDS_TTL_MS };
+          return [];
+        }
 
         const response = await axios.post(`${AI_SERVICE_URL}/api/trends`, {
           posts: recentPosts.map((p) => ({
@@ -47,10 +58,11 @@ const resolvers = {
           })),
         });
 
+        trendsCache = { data: response.data.trends, expiresAt: Date.now() + TRENDS_TTL_MS };
         return response.data.trends;
       } catch (error) {
         console.error('AI trend detection failed:', error.message);
-        return [];
+        return trendsCache.data || [];
       }
     },
   },


### PR DESCRIPTION
**Model swap all 5 AI services now use gemini-1.5-flash instead of gemini-2.0-flash:**

- [summarization.js](vscode-webview://0uvvul205mu13enr86vg6cv3i1n8k6j5h2v3ljfiresjmiitv6b5/server/services/ai-service/services/summarization.js)
- [sentiment.js](vscode-webview://0uvvul205mu13enr86vg6cv3i1n8k6j5h2v3ljfiresjmiitv6b5/server/services/ai-service/services/sentiment.js)
- [trends.js](vscode-webview://0uvvul205mu13enr86vg6cv3i1n8k6j5h2v3ljfiresjmiitv6b5/server/services/ai-service/services/trends.js)
- [matching.js](vscode-webview://0uvvul205mu13enr86vg6cv3i1n8k6j5h2v3ljfiresjmiitv6b5/server/services/ai-service/services/matching.js)
- [eventOptimizer.js](vscode-webview://0uvvul205mu13enr86vg6cv3i1n8k6j5h2v3ljfiresjmiitv6b5/server/services/ai-service/services/eventOptimizer.js)


**Trends cache in [communityResolvers.js](vscode-webview://0uvvul205mu13enr86vg6cv3i1n8k6j5h2v3ljfiresjmiitv6b5/server/services/community-service/resolvers/communityResolvers.js):**

10-minute in-memory TTL
First page load computes trends, next 10 minutes serve from memory
Falls back to last cached value on AI errors instead of returning []
Skips the AI call entirely when there are no posts