### PR TITLE
Add business image upload support with gallery and validation

### DIFF
--- a/remote-community/src/business/graphql/mutations.js
+++ b/remote-community/src/business/graphql/mutations.js
@@ -65,6 +65,15 @@ export const ADD_DEAL = gql`
   }
 `;
 
+export const ADD_BUSINESS_IMAGE = gql`
+  mutation AddBusinessImage($businessId: ID!, $image: String!) {
+    addBusinessImage(businessId: $businessId, image: $image) {
+      id
+      images
+    }
+  }
+`;
+
 export const REPLY_TO_REVIEW = gql`
   mutation ReplyToReview($businessId: ID!, $reviewIndex: Int!, $reply: String!) {
     replyToReview(businessId: $businessId, reviewIndex: $reviewIndex, reply: $reply) {

--- a/remote-community/src/business/graphql/queries.js
+++ b/remote-community/src/business/graphql/queries.js
@@ -50,6 +50,7 @@ export const GET_BUSINESS = gql`
       phone
       website
       hours
+      images
       deals {
         title
         description

--- a/remote-community/src/business/pages/BusinessDetailPage.jsx
+++ b/remote-community/src/business/pages/BusinessDetailPage.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery, useMutation } from '@apollo/client';
 import { GET_BUSINESS } from '../graphql/queries';
-import { ADD_REVIEW, ADD_DEAL, REPLY_TO_REVIEW } from '../graphql/mutations';
+import { ADD_REVIEW, ADD_DEAL, REPLY_TO_REVIEW, ADD_BUSINESS_IMAGE } from '../graphql/mutations';
 import { useAuth } from '../../shared/context/AuthContext';
 
 const sentimentColors = {
@@ -41,6 +41,10 @@ export default function BusinessDetailPage() {
   const [replyError, setReplyError] = useState('');
   const [replySuccess, setReplySuccess] = useState('');
 
+  const [imageFile, setImageFile] = useState(null);
+  const [imageError, setImageError] = useState('');
+  const [imageSuccess, setImageSuccess] = useState('');
+
   const { data, loading, error } = useQuery(GET_BUSINESS, {
     variables: { id },
     fetchPolicy: 'network-only',
@@ -62,6 +66,19 @@ export default function BusinessDetailPage() {
       setDealError('');
     },
     onError: (err) => setDealError(err.message),
+  });
+
+  const [addBusinessImage, { loading: imageLoading }] = useMutation(ADD_BUSINESS_IMAGE, {
+    refetchQueries: [{ query: GET_BUSINESS, variables: { id } }],
+    onCompleted: () => {
+      setImageFile(null);
+      setImageError('');
+      setImageSuccess('Image uploaded successfully.');
+    },
+    onError: (err) => {
+      setImageError(err.message || 'Failed to upload image.');
+      setImageSuccess('');
+    },
   });
 
   const [replyToReview, { loading: replyLoading }] = useMutation(REPLY_TO_REVIEW, {
@@ -133,6 +150,39 @@ export default function BusinessDetailPage() {
     }));
   }
 
+  function fileToBase64(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = (error) => reject(error);
+    });
+  }
+
+  async function handleImageSubmit(e) {
+    e.preventDefault();
+
+    if (!imageFile) {
+      setImageError('Please select an image.');
+      setImageSuccess('');
+      return;
+    }
+
+    try {
+      const base64Image = await fileToBase64(imageFile);
+
+      await addBusinessImage({
+        variables: {
+          businessId: id,
+          image: base64Image,
+        },
+      });
+    } catch (err) {
+      setImageError('Failed to process image.');
+      setImageSuccess('');
+    }
+  }
+
   return (
     <div className="max-w-3xl mx-auto px-4 py-6">
       <Link to="/businesses" className="text-primary-600 hover:underline text-sm mb-4 block">
@@ -171,6 +221,64 @@ export default function BusinessDetailPage() {
           {biz.hours && <p>Hours: {biz.hours}</p>}
           <p className="text-gray-500">Owner: {biz.owner?.name || 'Unknown'}</p>
         </div>
+        {biz.images?.length > 0 && (
+          <div className="mt-6">
+            <h2 className="text-xl font-semibold text-gray-800 mb-4">Photos</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+              {biz.images.map((image, index) => (
+                <div
+                  key={index}
+                  className="overflow-hidden rounded-lg border border-gray-200 bg-gray-50"
+                >
+                  <img
+                    src={image}
+                    alt={`${biz.name} ${index + 1}`}
+                    className="w-full h-48 object-cover"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {isOwner && (
+          <form onSubmit={handleImageSubmit} className="mt-6 border-t border-gray-300 pt-6 space-y-3">
+            <h3 className="font-medium text-gray-700">Upload Business Image</h3>
+
+            {imageError && <p className="text-red-600 text-sm">{imageError}</p>}
+            {imageSuccess && <p className="text-green-600 text-sm">{imageSuccess}</p>}
+
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => {
+                const file = e.target.files?.[0] || null;
+
+                if (file && file.size > 5 * 1024 * 1024) {
+                  setImageFile(null);
+                  setImageError('Image must be smaller than 5 MB.');
+                  setImageSuccess('');
+                  return;
+                }
+
+                setImageFile(file);
+                setImageError('');
+                setImageSuccess('');
+              }}
+              className="block w-full text-sm text-gray-600"
+            />
+            <p className="text-xs text-gray-500">
+              Please upload an image smaller than 5 MB. Exact duplicate images are not allowed.
+            </p>
+
+            <button
+              type="submit"
+              disabled={imageLoading}
+              className="bg-primary-600 text-white px-4 py-2 rounded text-sm hover:bg-primary-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {imageLoading ? 'Uploading...' : 'Upload Image'}
+            </button>
+          </form>
+        )}
       </div>
 
       {/* Deals */}

--- a/server/gateway/index.js
+++ b/server/gateway/index.js
@@ -39,7 +39,8 @@ async function startGateway() {
   app.use(
     '/graphql',
     cors(),
-    express.json(),
+    express.json({ limit: '5mb' }),
+    express.urlencoded({ limit: '5mb', extended: true }),
     expressMiddleware(server, {
       // Forward the Authorization header to subgraph services
       context: async ({ req }) => ({

--- a/server/services/business-events-service/index.js
+++ b/server/services/business-events-service/index.js
@@ -24,7 +24,8 @@ async function start() {
   app.use(
     '/graphql',
     cors(),
-    express.json(),
+    express.json({ limit: '5mb' }),
+    express.urlencoded({ limit: '5mb', extended: true }),
     expressMiddleware(server, { context: buildContext })
   );
 

--- a/server/services/business-events-service/models/Business.js
+++ b/server/services/business-events-service/models/Business.js
@@ -39,6 +39,10 @@ const businessSchema = new mongoose.Schema(
     phone: String,
     website: String,
     hours: String,
+    images: {
+      type: [String],
+      default: [],
+    },
     deals: [
       {
         title: { type: String, required: true },

--- a/server/services/business-events-service/resolvers/businessEventsResolvers.js
+++ b/server/services/business-events-service/resolvers/businessEventsResolvers.js
@@ -124,6 +124,25 @@ const resolvers = {
       return business.save();
     },
 
+    addBusinessImage: async (_, { businessId, image }, { user }) => {
+      if (!user) throw new Error('Not authenticated');
+      if (!image?.trim()) throw new Error('Image is required');
+
+      const business = await Business.findById(businessId);
+      if (!business) throw new Error('Business not found');
+
+      if (business.ownerId !== user.id) {
+        throw new Error('Not authorized');
+      }
+
+      if (business.images.includes(image)) {
+        throw new Error('This image has already been uploaded.');
+      }
+
+      business.images.push(image);
+      return business.save();
+    },
+
     addReview: async (_, { businessId, rating, comment }, { user }) => {
       if (!user) throw new Error('Not authenticated');
       const business = await Business.findById(businessId);

--- a/server/services/business-events-service/schemas/businessEventsSchema.js
+++ b/server/services/business-events-service/schemas/businessEventsSchema.js
@@ -36,6 +36,7 @@ const typeDefs = gql`
     phone: String
     website: String
     hours: String
+    images: [String]
     deals: [Deal]
     reviews: [Review]
     averageRating: Float
@@ -123,6 +124,11 @@ const typeDefs = gql`
       title: String!
       description: String
       validUntil: String
+    ): Business!
+
+    addBusinessImage(
+      businessId: ID!
+      image: String!
     ): Business!
 
     addReview(


### PR DESCRIPTION
Implements business image upload functionality for business owners, completing the requirement for business profiles to include images.

Changes
- Added images field to Business model (MongoDB)
- Added addBusinessImage GraphQL mutation
- Implemented owner-only image upload logic in resolver
- Integrated image upload in frontend (BusinessDetailPage)
- Added base64 conversion using FileReader
- Displayed uploaded images in a responsive gallery for all users

Validation & UX Improvements
- Prevented duplicate image uploads (exact base64 match)
- Added frontend validation for image size (max 5MB)
- Displayed user-friendly error and success messages
- Restricted upload functionality to business owners only

Result
- Business owners can upload images to their listings
- Images are stored in MongoDB and displayed to all users
- Feature integrates cleanly with existing business detail page